### PR TITLE
[DRAFT] Apple Notification Center Service Implementation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -483,7 +483,7 @@ list(APPEND SOURCE_FILES
         components/ble/DfuService.cpp
         components/ble/CurrentTimeService.cpp
         components/ble/AlertNotificationService.cpp
-        components/ble/AppleNotificationCenterService.cpp
+        components/ble/AppleNotificationCenterClient.cpp
         components/ble/MusicService.cpp
         components/ble/weather/WeatherService.cpp
         components/ble/NavigationService.cpp
@@ -557,7 +557,7 @@ list(APPEND RECOVERY_SOURCE_FILES
         components/ble/DfuService.cpp
         components/ble/CurrentTimeService.cpp
         components/ble/AlertNotificationService.cpp
-        components/ble/AppleNotificationCenterService.cpp
+        components/ble/AppleNotificationCenterClient.cpp
         components/ble/MusicService.cpp
         components/ble/weather/WeatherService.cpp
         components/ble/BatteryInformationService.cpp
@@ -672,7 +672,7 @@ set(INCLUDE_FILES
         components/ble/DeviceInformationService.h
         components/ble/CurrentTimeClient.h
         components/ble/AlertNotificationClient.h
-        components/ble/AppleNotificationCenterService.h
+        components/ble/AppleNotificationCenterClient.h
         components/ble/DfuService.h
         components/firmwarevalidator/FirmwareValidator.h
         components/ble/BatteryInformationService.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -483,6 +483,7 @@ list(APPEND SOURCE_FILES
         components/ble/DfuService.cpp
         components/ble/CurrentTimeService.cpp
         components/ble/AlertNotificationService.cpp
+        components/ble/AppleNotificationCenterService.cpp
         components/ble/MusicService.cpp
         components/ble/weather/WeatherService.cpp
         components/ble/NavigationService.cpp
@@ -556,6 +557,7 @@ list(APPEND RECOVERY_SOURCE_FILES
         components/ble/DfuService.cpp
         components/ble/CurrentTimeService.cpp
         components/ble/AlertNotificationService.cpp
+        components/ble/AppleNotificationCenterService.cpp
         components/ble/MusicService.cpp
         components/ble/weather/WeatherService.cpp
         components/ble/BatteryInformationService.cpp
@@ -670,6 +672,7 @@ set(INCLUDE_FILES
         components/ble/DeviceInformationService.h
         components/ble/CurrentTimeClient.h
         components/ble/AlertNotificationClient.h
+        components/ble/AppleNotificationCenterService.h
         components/ble/DfuService.h
         components/firmwarevalidator/FirmwareValidator.h
         components/ble/BatteryInformationService.h

--- a/src/components/ble/AppleNotificationCenterClient.cpp
+++ b/src/components/ble/AppleNotificationCenterClient.cpp
@@ -1,0 +1,140 @@
+#include "components/ble/AppleNotificationCenterClient.h"
+#include <algorithm>
+#include "components/ble/NotificationManager.h"
+#include "systemtask/SystemTask.h"
+
+using namespace Pinetime::Controllers;
+
+
+int OnDiscoveryEventCallback(uint16_t conn_handle, const struct ble_gatt_error* error, const struct ble_gatt_svc* service, void* arg) {
+  auto client = static_cast<AppleNotificationCenterClient*>(arg);
+  return client->OnDiscoveryEvent(conn_handle, error, service);
+}
+
+int OnANCSCharacteristicDiscoveredCallback(uint16_t conn_handle,
+                                           const struct ble_gatt_error* error,
+                                           const struct ble_gatt_chr* chr,
+                                           void* arg) {
+  auto client = static_cast<AppleNotificationCenterClient*>(arg);
+  return client->OnCharacteristicsDiscoveryEvent(conn_handle, error, chr);
+}
+
+int OnANCSDescriptorDiscoveryEventCallback(
+  uint16_t conn_handle, const struct ble_gatt_error* error, uint16_t chr_val_handle, const struct ble_gatt_dsc* dsc, void* arg) {
+  auto client = static_cast<AppleNotificationCenterClient*>(arg);
+  return client->OnDescriptorDiscoveryEventCallback(conn_handle, error, chr_val_handle, dsc);
+}
+
+int NewAlertSubcribeCallback(uint16_t conn_handle, const struct ble_gatt_error* error, struct ble_gatt_attr* attr, void* arg) {
+  auto client = static_cast<AppleNotificationCenterClient*>(arg);
+  return client->OnNewAlertSubcribe(conn_handle, error, attr);
+}
+
+AppleNotificationCenterClient::AppleNotificationCenterClient(Pinetime::System::SystemTask& systemTask,
+                                                 Pinetime::Controllers::NotificationManager& notificationManager)
+  : systemTask {systemTask}, notificationManager {notificationManager} {
+}
+
+bool AppleNotificationCenterClient::OnDiscoveryEvent(uint16_t connectionHandle, const ble_gatt_error* error, const ble_gatt_svc* service) {
+  if (service == nullptr && error->status == BLE_HS_EDONE) {
+    if (isDiscovered) {
+      NRF_LOG_INFO("ANCS Discovery found, starting characteristics discovery");
+
+      ble_gattc_disc_all_chrs(connectionHandle, ancsStartHandle, ancsEndHandle, OnANCSCharacteristicDiscoveredCallback, this);
+    } else {
+      NRF_LOG_INFO("ANCS not found");
+      onServiceDiscovered(connectionHandle);
+    }
+    return true;
+  }
+
+  if (service != nullptr && ble_uuid_cmp(&ancsUuid.u, &service->uuid.u) == 0) {
+    NRF_LOG_INFO("ANCS discovered : 0x%x - 0x%x", service->start_handle, service->end_handle);
+    ancsStartHandle = service->start_handle;
+    ancsEndHandle = service->end_handle;
+    isDiscovered = true;
+  }
+  return false;
+}
+
+int AppleNotificationCenterClient::OnCharacteristicsDiscoveryEvent(uint16_t connectionHandle, const ble_gatt_error* error, const ble_gatt_chr* characteristic) {
+  if (error->status != 0 && error->status != BLE_HS_EDONE) {
+    NRF_LOG_INFO("ANCS Characteristic discovery ERROR");
+    onServiceDiscovered(connectionHandle);
+    return 0;
+  }
+
+  if (characteristic == nullptr && error->status == BLE_HS_EDONE) {
+    NRF_LOG_INFO("ANCS Characteristic discovery complete");
+    if (isCharacteristicDiscovered) {
+      ble_gattc_disc_all_dscs(connectionHandle, notificationSourceHandle, ancsEndHandle, OnANCSDescriptorDiscoveryEventCallback, this);
+    } else {
+      onServiceDiscovered(connectionHandle);
+    }
+  } else {
+    if (characteristic != nullptr && ble_uuid_cmp(&notificationSourceChar.u, &characteristic->uuid.u) == 0) {
+      NRF_LOG_INFO("ANCS Characteristic discovered: Notification Source");
+      notificationSourceHandle = characteristic->val_handle;
+      // notificationSourceDefHandle = characteristic->def_handle;
+      isCharacteristicDiscovered = true;
+    }
+  }
+  return 0;
+}
+
+int AppleNotificationCenterClient::OnDescriptorDiscoveryEventCallback(uint16_t connectionHandle, const ble_gatt_error* error, uint16_t characteristicValueHandle, const ble_gatt_dsc* descriptor) {
+  if (error->status == 0) {
+    if (characteristicValueHandle == notificationSourceHandle && ble_uuid_cmp(&notificationSourceChar.u, &descriptor->uuid.u)) {
+      if (notificationSourceDescriptorHandle == 0) {
+        NRF_LOG_INFO("ANCS Descriptor discovered : %d", descriptor->handle);
+        notificationSourceDescriptorHandle = descriptor->handle;
+        isDescriptorFound = true;
+        uint8_t value[2] {1, 0};
+        ble_gattc_write_flat(connectionHandle, notificationSourceDescriptorHandle, value, sizeof(value), NewAlertSubcribeCallback, this);
+      }
+    }
+  } else {
+    if (!isDescriptorFound)
+      onServiceDiscovered(connectionHandle);
+  }
+  return 0;
+}
+
+int AppleNotificationCenterClient::OnNewAlertSubcribe(uint16_t connectionHandle, const ble_gatt_error* error, ble_gatt_attr* attribute) {
+  if (error->status == 0) {
+    NRF_LOG_INFO("ANCS New alert subscribe OK");
+  } else {
+    NRF_LOG_INFO("ANCS New alert subscribe ERROR");
+  }
+  onServiceDiscovered(connectionHandle);
+
+  return 0;
+}
+
+void AppleNotificationCenterClient::OnNotification(ble_gap_event* event) {
+  if (event->notify_rx.attr_handle == notificationSourceHandle) {
+    NotificationManager::Notification notif;
+    notif.message = std::array<char, 101> {"Hello\0World"};
+    notif.size = 11;
+    notif.category = Pinetime::Controllers::NotificationManager::Categories::SimpleAlert;
+    notificationManager.Push(std::move(notif));
+
+    systemTask.PushMessage(Pinetime::System::Messages::OnNewNotification);
+  }
+}
+
+void AppleNotificationCenterClient::Reset() {
+  ancsStartHandle = 0;
+  ancsEndHandle = 0;
+  notificationSourceHandle = 0;
+  notificationSourceDescriptorHandle = 0;
+  isDiscovered = false;
+  isCharacteristicDiscovered = false;
+  isDescriptorFound = false;
+}
+
+void AppleNotificationCenterClient::Discover(uint16_t connectionHandle, std::function<void(uint16_t)> onServiceDiscovered) {
+  NRF_LOG_INFO("[ANCS] Starting discovery");
+  this->onServiceDiscovered = onServiceDiscovered;
+  ble_gattc_disc_svc_by_uuid(connectionHandle, &ancsUuid.u, OnDiscoveryEventCallback, this);
+}

--- a/src/components/ble/AppleNotificationCenterClient.h
+++ b/src/components/ble/AppleNotificationCenterClient.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#define min // workaround: nimble's min/max macros conflict with libstdc++
+#define max
+#include <host/ble_gap.h>
+#undef max
+#undef min
+#include "components/ble/BleClient.h"
+
+namespace Pinetime {
+
+  namespace System {
+    class SystemTask;
+  }
+
+  namespace Controllers {
+    class NotificationManager;
+
+    class AppleNotificationCenterClient : public BleClient {
+    public:
+      explicit AppleNotificationCenterClient(Pinetime::System::SystemTask& systemTask,
+                                       Pinetime::Controllers::NotificationManager& notificationManager);
+
+      bool OnDiscoveryEvent(uint16_t connectionHandle, const ble_gatt_error* error, const ble_gatt_svc* service);
+      int OnCharacteristicsDiscoveryEvent(uint16_t connectionHandle, const ble_gatt_error* error, const ble_gatt_chr* characteristic);
+      int OnNewAlertSubcribe(uint16_t connectionHandle, const ble_gatt_error* error, ble_gatt_attr* attribute);
+      int OnDescriptorDiscoveryEventCallback(uint16_t connectionHandle, const ble_gatt_error* error, uint16_t characteristicValueHandle, const ble_gatt_dsc* descriptor);
+      void OnNotification(ble_gap_event* event);
+      void Reset();
+      void Discover(uint16_t connectionHandle, std::function<void(uint16_t)> lambda) override;
+
+    private:
+      // 7905F431-B5CE-4E99-A40F-4B1E122D00D0
+      const ble_uuid128_t ancsUuid { 
+        {BLE_UUID_TYPE_128},
+        {0xd0, 0x00, 0x2D, 0x12, 0x1E, 0x4B, 0x0F, 0x24, 0x99, 0x0E, 0xCE, 0xB5, 0x31, 0xF4, 0x05, 0x79}
+      };
+
+      // 9FBF120D-6301-42D9-8C58-25E699A21DBD
+      const ble_uuid128_t notificationSourceChar { 
+        {BLE_UUID_TYPE_128}, 
+        {0xBD, 0x1D, 0xA2, 0x99, 0xE6, 0x25, 0x58, 0X0C, 0xD9, 0x02, 0x01, 0x63, 0x0D, 0x12, 0xBF, 0x9F}
+      };
+      // 69D1D8F3-45E1-49A8-9821-9BBDFDAAD9D9
+      const ble_uuid128_t controlPointChar {
+        {BLE_UUID_TYPE_128},
+        {0xD9, 0xD9, 0xAA, 0xFD, 0xBD, 0x9B, 0x21, 0X18,0xA8, 0x09,0xE1, 0x45, 0xF3, 0xD8, 0xD1, 0x69 }
+      };
+      // 22EAC6E9-24D6-4BB5-BE44-B36ACE7C7BFB
+      const ble_uuid128_t dataSourceChar {
+        {BLE_UUID_TYPE_128},
+        {0xFB, 0x7B, 0x7C, 0xCE, 0x6A, 0xB3, 0x44, 0X3E,0xB5, 0x0B,0xD6, 0x24, 0xE9, 0xC6, 0xEA, 0x22 }
+      };
+
+      uint16_t ancsStartHandle {0};
+      uint16_t ancsEndHandle {0};
+      uint16_t notificationSourceHandle {0};
+      //uint16_t controlPointHandle {0};
+      //uint16_t dataSourceHandle {0};
+      uint16_t notificationSourceDescriptorHandle {0};
+      bool isDiscovered {false};
+      bool isCharacteristicDiscovered {false};
+      bool isDescriptorFound {false};
+      Pinetime::System::SystemTask& systemTask;
+      Pinetime::Controllers::NotificationManager& notificationManager;
+      std::function<void(uint16_t)> onServiceDiscovered;
+    };
+  }
+}

--- a/src/components/ble/AppleNotificationCenterService.cpp
+++ b/src/components/ble/AppleNotificationCenterService.cpp
@@ -95,7 +95,7 @@ int AppleNotificationCenterService::OnAlert(uint16_t conn_handle, uint16_t attr_
 
 // Handle data from dataSourceChar
 int AppleNotificationCenterService::OnData(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt) {
-
+  return 0;
 }
 
 // Send a Get Notification Attributes command to Control Point

--- a/src/components/ble/AppleNotificationCenterService.cpp
+++ b/src/components/ble/AppleNotificationCenterService.cpp
@@ -9,9 +9,14 @@ constexpr ble_uuid128_t AppleNotificationCenterService::ancsChar;
 constexpr ble_uuid128_t AppleNotificationCenterService::dataSourceChar;
 constexpr ble_uuid128_t AppleNotificationCenterService::controlPointChar;
 
-int AppleNotificationCenterCallback(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt, void* arg) {
+int AppleNotificationCenterAlertCallback(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt, void* arg) {
   auto ancService = static_cast<AppleNotificationCenterService*>(arg);
   return ancService->OnAlert(conn_handle, attr_handle, ctxt);
+}
+
+int AppleNotificationCenterDataCallback(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt, void* arg) {
+  auto ancService = static_cast<AppleNotificationCenterService*>(arg);
+  return ancService->OnData(conn_handle, attr_handle, ctxt);
 }
 
 void AppleNotificationCenterService::Init() {
@@ -25,8 +30,10 @@ void AppleNotificationCenterService::Init() {
 
 AppleNotificationCenterService::AppleNotificationCenterService(System::SystemTask& systemTask, NotificationManager& notificationManager)
   : characteristicDefinition {
-    {.uuid = &ancsChar.u, .access_cb = AppleNotificationCenterCallback, .arg = this, .flags = BLE_GATT_CHR_F_NOTIFY},
-    {.uuid =  0}},
+    {.uuid = &ancsChar.u, .access_cb = AppleNotificationCenterAlertCallback, .arg = this, .flags = BLE_GATT_CHR_F_NOTIFY},
+    {.uuid = &controlPointChar}, // TODO
+    {.uuid = &dataSourceChar, .access_cb = AppleNotificationCenterAlertCallback, .arg = this, .flags = BLE_GATT_CHR_F_NOTIFY},
+    {0}},
     serviceDefinition {
       {/* Device Information Service */
        .type = BLE_GATT_SVC_TYPE_PRIMARY,
@@ -85,3 +92,16 @@ int AppleNotificationCenterService::OnAlert(uint16_t conn_handle, uint16_t attr_
   }
   return 0;
 }
+
+// Handle data from dataSourceChar
+int AppleNotificationCenterService::OnData(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt) {
+
+}
+
+// Send a Get Notification Attributes command to Control Point
+void AppleNotificationCenterService::GetNotificationAttribute() {}
+// Send a Get App Attributes command to Control Point
+void AppleNotificationCenterService::GetAppAttributes() {}
+// Send a Perform Notification Action command to Control Point
+void AppleNotificationCenterService::PerformNitificationAction() {}
+

--- a/src/components/ble/AppleNotificationCenterService.cpp
+++ b/src/components/ble/AppleNotificationCenterService.cpp
@@ -38,6 +38,7 @@ AppleNotificationCenterService::AppleNotificationCenterService(System::SystemTas
     systemTask {systemTask},
     notificationManager {notificationManager} {}
 
+// Handle notification
 int AppleNotificationCenterService::OnAlert(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt) {
   if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
     Event event;
@@ -52,6 +53,35 @@ int AppleNotificationCenterService::OnAlert(uint16_t conn_handle, uint16_t attr_
     os_mbuf_copydata(ctxt->om, 2, 1, &category);
     os_mbuf_copydata(ctxt->om, 3, 1, &categoryCount);
     os_mbuf_copydata(ctxt->om, 4, 32, &notificationUUID);
+
+    switch (category) {
+      case Category::Email:
+        notif.category = Pinetime::Controllers::NotificationManager::Categories::Email;
+        break;
+      case Category::IncomingCall:
+        notif.category = Pinetime::Controllers::NotificationManager::Categories::IncomingCall;
+        break;
+      case Category::MissedCall:
+        notif.category = Pinetime::Controllers::NotificationManager::Categories::MissedCall;
+        break;
+      case Category::News:
+        notif.category = Pinetime::Controllers::NotificationManager::Categories::News;
+        break;
+      case Category::Schedule:
+        notif.category = Pinetime::Controllers::NotificationManager::Categories::Sms;
+        break;
+      case Category::Voicemail:
+        notif.category = Pinetime::Controllers::NotificationManager::Categories::VoiceMail;
+        break;
+      default:
+        notif.category = Pinetime::Controllers::NotificationManager::Categories::SimpleAlert;
+        break;
+    }
+    
+    auto notifEvent = Pinetime::System::Messages::OnNewNotification;
+    notificationManager.Push(std::move(notif));
+    systemTask.PushMessage(notifEvent);
+ 
   }
   return 0;
 }

--- a/src/components/ble/AppleNotificationCenterService.cpp
+++ b/src/components/ble/AppleNotificationCenterService.cpp
@@ -5,6 +5,7 @@
 
 using namespace Pinetime::Controllers;
 
+constexpr ble_uuid128_t AppleNotificationCenterService::ancsSvc;
 constexpr ble_uuid128_t AppleNotificationCenterService::ancsChar;
 constexpr ble_uuid128_t AppleNotificationCenterService::dataSourceChar;
 constexpr ble_uuid128_t AppleNotificationCenterService::controlPointChar;
@@ -31,13 +32,12 @@ void AppleNotificationCenterService::Init() {
 AppleNotificationCenterService::AppleNotificationCenterService(System::SystemTask& systemTask, NotificationManager& notificationManager)
   : characteristicDefinition {
     {.uuid = &ancsChar.u, .access_cb = AppleNotificationCenterAlertCallback, .arg = this, .flags = BLE_GATT_CHR_F_NOTIFY},
-    {.uuid = &controlPointChar}, // TODO
-    {.uuid = &dataSourceChar, .access_cb = AppleNotificationCenterAlertCallback, .arg = this, .flags = BLE_GATT_CHR_F_NOTIFY},
+    {.uuid = &dataSourceChar.u, .access_cb = AppleNotificationCenterDataCallback, .arg = this, .flags = BLE_GATT_CHR_F_NOTIFY},
     {0}},
     serviceDefinition {
       {/* Device Information Service */
        .type = BLE_GATT_SVC_TYPE_PRIMARY,
-       .uuid = &ancsChar.u,
+       .uuid = &ancsSvc.u,
        .characteristics = characteristicDefinition
       },
       {0},
@@ -103,5 +103,5 @@ void AppleNotificationCenterService::GetNotificationAttribute() {}
 // Send a Get App Attributes command to Control Point
 void AppleNotificationCenterService::GetAppAttributes() {}
 // Send a Perform Notification Action command to Control Point
-void AppleNotificationCenterService::PerformNitificationAction() {}
+void AppleNotificationCenterService::PerformNotificationAction() {}
 

--- a/src/components/ble/AppleNotificationCenterService.cpp
+++ b/src/components/ble/AppleNotificationCenterService.cpp
@@ -1,0 +1,57 @@
+#include "components/ble/AppleNotificationCenterService.h"
+#include <hal/nrf_rtc.h>
+#include "components/ble/NotificationManager.h"
+#include "systemtask/SystemTask.h"
+
+using namespace Pinetime::Controllers;
+
+constexpr ble_uuid128_t AppleNotificationCenterService::ancsChar;
+constexpr ble_uuid128_t AppleNotificationCenterService::dataSourceChar;
+constexpr ble_uuid128_t AppleNotificationCenterService::controlPointChar;
+
+int AppleNotificationCenterCallback(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt, void* arg) {
+  auto ancService = static_cast<AppleNotificationCenterService*>(arg);
+  return ancService->OnAlert(conn_handle, attr_handle, ctxt);
+}
+
+void AppleNotificationCenterService::Init() {
+  int res;
+  res = ble_gatts_count_cfg(serviceDefinition);
+  ASSERT(res == 0);
+
+  res = ble_gatts_add_svcs(serviceDefinition);
+  ASSERT(res == 0);
+}
+
+AppleNotificationCenterService::AppleNotificationCenterService(System::SystemTask& systemTask, NotificationManager& notificationManager)
+  : characteristicDefinition {
+    {.uuid = &ancsChar.u, .access_cb = AppleNotificationCenterCallback, .arg = this, .flags = BLE_GATT_CHR_F_NOTIFY},
+    {.uuid =  0}},
+    serviceDefinition {
+      {/* Device Information Service */
+       .type = BLE_GATT_SVC_TYPE_PRIMARY,
+       .uuid = &ancsChar.u,
+       .characteristics = characteristicDefinition
+      },
+      {0},
+    },
+    systemTask {systemTask},
+    notificationManager {notificationManager} {}
+
+int AppleNotificationCenterService::OnAlert(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt) {
+  if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
+    Event event;
+    EventFlag eventFlag;
+    Category category;
+    size_t categoryCount;
+    uint32_t notificationUUID;
+
+    NotificationManager::Notification notif;
+    os_mbuf_copydata(ctxt->om, 0, 1, &event);
+    os_mbuf_copydata(ctxt->om, 1, 1, &eventFlag);
+    os_mbuf_copydata(ctxt->om, 2, 1, &category);
+    os_mbuf_copydata(ctxt->om, 3, 1, &categoryCount);
+    os_mbuf_copydata(ctxt->om, 4, 32, &notificationUUID);
+  }
+  return 0;
+}

--- a/src/components/ble/AppleNotificationCenterService.cpp
+++ b/src/components/ble/AppleNotificationCenterService.cpp
@@ -31,8 +31,11 @@ void AppleNotificationCenterService::Init() {
 
 AppleNotificationCenterService::AppleNotificationCenterService(System::SystemTask& systemTask, NotificationManager& notificationManager)
   : characteristicDefinition {
-    {.uuid = &ancsChar.u, .access_cb = AppleNotificationCenterAlertCallback, .arg = this, .flags = BLE_GATT_CHR_F_NOTIFY},
-    {.uuid = &dataSourceChar.u, .access_cb = AppleNotificationCenterDataCallback, .arg = this, .flags = BLE_GATT_CHR_F_NOTIFY},
+    {.uuid = &ancsChar.u, .access_cb = AppleNotificationCenterAlertCallback, .arg = this, .flags = BLE_GATT_CHR_F_NOTIFY
+                                                                                                     | BLE_GATT_CHR_F_READ_ENC |
+                                                                                                     BLE_GATT_CHR_F_READ_AUTHEN},
+    {.uuid = &dataSourceChar.u, .access_cb = AppleNotificationCenterDataCallback, .arg = this, .flags = BLE_GATT_CHR_F_NOTIFY
+                                                                                                          | BLE_GATT_CHR_F_READ_ENC | BLE_GATT_CHR_F_READ_AUTHEN},
     {0}},
     serviceDefinition {
       {/* Device Information Service */

--- a/src/components/ble/AppleNotificationCenterService.h
+++ b/src/components/ble/AppleNotificationCenterService.h
@@ -19,7 +19,7 @@
 namespace Pinetime {
     
     namespace System {
-        class SystemTask
+        class SystemTask;
     }
 
     namespace Controllers {

--- a/src/components/ble/AppleNotificationCenterService.h
+++ b/src/components/ble/AppleNotificationCenterService.h
@@ -31,6 +31,12 @@ namespace Pinetime {
                 void Init();
                 
                 int OnAlert(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt);
+
+                int OnData(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access ctxt* ctxt);
+
+                void GetNotificationAttribute();
+                void GetAppAttributes();
+                void PerformNotificationAction();
             private:
                /**
                * see: https://developer.apple.com/library/archive/documentation/CoreBluetooth/Reference/AppleNotificationCenterServiceSpecification/Appendix/Appendix.html#//apple_ref/doc/uid/TP40013460-CH3-SW2

--- a/src/components/ble/AppleNotificationCenterService.h
+++ b/src/components/ble/AppleNotificationCenterService.h
@@ -113,7 +113,7 @@ namespace Pinetime {
                                                                    {0xFB, 0x7B, 0x7C, 0xCE, 0x6A, 0xB3,
                                                                     0x44, 0X3E,0xB5, 0x0B,0xD6, 0x24, 0xE9,
                                                                     0xC6, 0xEA, 0x22 }};
-                struct ble_gatt_chr_def characteristicDefinition[2];
+                struct ble_gatt_chr_def characteristicDefinition[4];
                 struct ble_gatt_svc_def serviceDefinition[2];
                 
                 Pinetime::System::SystemTask& systemTask;

--- a/src/components/ble/AppleNotificationCenterService.h
+++ b/src/components/ble/AppleNotificationCenterService.h
@@ -1,0 +1,115 @@
+#pragma once
+#include <cstdint>
+#include <array>
+#define min // workaround: nimble's min/max macros conflict with libstdc++
+#define max
+#include <host/ble_gap.h>
+#include <host/ble_uuid.h>
+#undef max
+#undef min
+
+/**
+ * UUID Apple Notification Center Service : 7905F431-B5CE-4E99-A40F-4B1E122D00D0
+ * Value obtains by decoding this uuid to string, reversing the result and prefixing all part with 0x
+ */
+#define APPLE_NOTIFICATION_CENTER_SERVICE_UUID_BASE                                                                                               \
+  { 0xd0, 0x00, 0x2D, 0x12, 0x1E, 0x4B, 0x0F, 0x24, 0x99, 0x0E, 0xCE, 0xB5, 0x31, 0xF4, 0x05, 0x79 }
+
+
+namespace Pinetime {
+    
+    namespace System {
+        class SystemTask
+    }
+
+    namespace Controllers {
+        class NotificationManager;
+
+        class AppleNotificationCenterService {
+            public:
+                AppleNotificationCenterService(Pinetime::System::SystemTask& systemTask, Pinetime::Controllers::NotificationManager& notificationManager);
+                void Init();
+                
+                int OnAlert(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt);
+            private:
+               /**
+               * see: https://developer.apple.com/library/archive/documentation/CoreBluetooth/Reference/AppleNotificationCenterServiceSpecification/Appendix/Appendix.html#//apple_ref/doc/uid/TP40013460-CH3-SW2
+               */
+                enum class Category : uint8_t {
+                  Other = 0x00,
+                  IncomingCall = 0x01,
+                  MissedCall = 0x02,
+                  Voicemail = 0x03,
+                  Social = 0x04,
+                  Schedule = 0x05,
+                  Email = 0x06,
+                  News = 0x07,
+                  HealthAndFitness = 0x08,
+                  BusinessAndFinance = 0x09,
+                  Location = 0x10,
+                  Entertainment = 0x11
+                };
+
+                enum class Event : uint8_t {
+                  NotificationAdded = 0x00,
+                  NotificationModified = 0x01,
+                  NotificationRemoved = 0x02
+                };
+
+                enum class EventFlag : uint8_t {
+                  Silent = 0x00,
+                  Important = 0x01,
+                  PreExisting = 0x02,
+                  PositiveAction = 0x03,
+                  NegativeAction = 0x04,
+                  Schedule = 0x05
+                };
+
+                enum class Command : uint8_t {
+                  GetNotificationAttributes = 0x00,
+                  GetAppAttributes = 0x01,
+                  PerformNotificationAction = 0x02
+                };
+
+                enum class NotificationAttribute : uint8_t {
+                  AppIdentifier = 0x00,
+                  Title = 0x01,
+                  Subtitle = 0x02,
+                  Message = 0x03,
+                  MessageSize = 0x04,
+                  Date = 0x05,
+                  PositiveActionLabel = 0x06,
+                  NegativeActionLabel = 0x07
+                };
+
+                enum class Action : uint8_t {
+                  Positive = 0x00,
+                  Negative = 0x01
+                };
+
+                enum class AppAttribute : uint8_t {
+                  DisplayName = 0x00
+                };
+
+                // 9FBF120D-6301-42D9-8C58-25E699A21DBD
+                static constexpr ble_uuid128_t ancsChar { {BLE_UUID_TYPE_128}, {0xBD, 0x1D, 0xA2, 0x99,
+                                                                                 0xE6, 0x25, 0x58, 0X0C, 0xD9, 0x02,
+                                                           0x01, 0x63, 0x0D,0x12, 0xBF, 0x9F}};
+                // 69D1D8F3-45E1-49A8-9821-9BBDFDAAD9D9
+                static constexpr ble_uuid128_t controlPointChar {{BLE_UUID_TYPE_128},
+                                                                   {0xD9, 0xD9, 0xAA, 0xFD, 0xBD, 0x9B,
+                                                                    0x21, 0X18,0xA8, 0x09,0xE1, 0x45, 0xF3,
+                                                                    0xD8, 0xD1, 0x69 }};
+                // 22EAC6E9-24D6-4BB5-BE44-B36ACE7C7BFB
+                static constexpr ble_uuid128_t dataSourceChar {{BLE_UUID_TYPE_128},
+                                                                   {0xFB, 0x7B, 0x7C, 0xCE, 0x6A, 0xB3,
+                                                                    0x44, 0X3E,0xB5, 0x0B,0xD6, 0x24, 0xE9,
+                                                                    0xC6, 0xEA, 0x22 }};
+                struct ble_gatt_chr_def characteristicDefinition[2];
+                struct ble_gatt_svc_def serviceDefinition[2];
+                
+                Pinetime::System::SystemTask& systemTask;
+                NotificationManager& notificationManager;
+        };
+    }
+}

--- a/src/components/ble/AppleNotificationCenterService.h
+++ b/src/components/ble/AppleNotificationCenterService.h
@@ -32,7 +32,7 @@ namespace Pinetime {
                 
                 int OnAlert(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt);
 
-                int OnData(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access ctxt* ctxt);
+                int OnData(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt);
 
                 void GetNotificationAttribute();
                 void GetAppAttributes();
@@ -96,6 +96,8 @@ namespace Pinetime {
                 enum class AppAttribute : uint8_t {
                   DisplayName = 0x00
                 };
+                
+                static constexpr ble_uuid128_t ancsSvc { { BLE_UUID_TYPE_128}, APPLE_NOTIFICATION_CENTER_SERVICE_UUID_BASE};
 
                 // 9FBF120D-6301-42D9-8C58-25E699A21DBD
                 static constexpr ble_uuid128_t ancsChar { {BLE_UUID_TYPE_128}, {0xBD, 0x1D, 0xA2, 0x99,

--- a/src/components/ble/NimbleController.cpp
+++ b/src/components/ble/NimbleController.cpp
@@ -19,6 +19,7 @@
 #include "components/datetime/DateTimeController.h"
 #include "components/fs/FS.h"
 #include "systemtask/SystemTask.h"
+#include "components/ble/AppleNotificationCenterService.h"
 
 using namespace Pinetime::Controllers;
 
@@ -38,10 +39,10 @@ NimbleController::NimbleController(Pinetime::System::SystemTask& systemTask,
     spiNorFlash {spiNorFlash},
     fs {fs},
     dfuService {systemTask, bleController, spiNorFlash},
-
     currentTimeClient {dateTimeController},
     anService {systemTask, notificationManager},
     alertNotificationClient {systemTask, notificationManager},
+    appleNotificationCenterService {systemTask, notificationManager},
     currentTimeService {dateTimeController},
     musicService {systemTask},
     weatherService {systemTask, dateTimeController},
@@ -93,6 +94,7 @@ void NimbleController::Init() {
   weatherService.Init();
   navService.Init();
   anService.Init();
+  appleNotificationCenterService.Init();
   dfuService.Init();
   batteryInformationService.Init();
   immediateAlertService.Init();

--- a/src/components/ble/NimbleController.cpp
+++ b/src/components/ble/NimbleController.cpp
@@ -19,7 +19,6 @@
 #include "components/datetime/DateTimeController.h"
 #include "components/fs/FS.h"
 #include "systemtask/SystemTask.h"
-#include "components/ble/AppleNotificationCenterService.h"
 
 using namespace Pinetime::Controllers;
 
@@ -42,7 +41,7 @@ NimbleController::NimbleController(Pinetime::System::SystemTask& systemTask,
     currentTimeClient {dateTimeController},
     anService {systemTask, notificationManager},
     alertNotificationClient {systemTask, notificationManager},
-    appleNotificationCenterService {systemTask, notificationManager},
+    appleNotificationCenterClient {systemTask, notificationManager},
     currentTimeService {dateTimeController},
     musicService {systemTask},
     weatherService {systemTask, dateTimeController},
@@ -52,7 +51,7 @@ NimbleController::NimbleController(Pinetime::System::SystemTask& systemTask,
     heartRateService {systemTask, heartRateController},
     motionService {systemTask, motionController},
     fsService {systemTask, fs},
-    serviceDiscovery({&currentTimeClient, &alertNotificationClient}) {
+    serviceDiscovery({&currentTimeClient, &alertNotificationClient, &appleNotificationCenterClient}) {
 }
 
 void nimble_on_reset(int reason) {
@@ -94,7 +93,6 @@ void NimbleController::Init() {
   weatherService.Init();
   navService.Init();
   anService.Init();
-  appleNotificationCenterService.Init();
   dfuService.Init();
   batteryInformationService.Init();
   immediateAlertService.Init();
@@ -198,6 +196,7 @@ int NimbleController::OnGAPEvent(ble_gap_event* event) {
         /* Connection failed; resume advertising. */
         currentTimeClient.Reset();
         alertNotificationClient.Reset();
+        appleNotificationCenterClient.Reset();
         connectionHandle = BLE_HS_CONN_HANDLE_NONE;
         bleController.Disconnect();
         fastAdvCount = 0;
@@ -221,6 +220,7 @@ int NimbleController::OnGAPEvent(ble_gap_event* event) {
 
       currentTimeClient.Reset();
       alertNotificationClient.Reset();
+      appleNotificationCenterClient.Reset();
       connectionHandle = BLE_HS_CONN_HANDLE_NONE;
       bleController.Disconnect();
       fastAdvCount = 0;
@@ -366,6 +366,7 @@ int NimbleController::OnGAPEvent(ble_gap_event* event) {
                    notifSize);
 
       alertNotificationClient.OnNotification(event);
+      appleNotificationCenterClient.OnNotification(event);
     } break;
 
     case BLE_GAP_EVENT_NOTIFY_TX:

--- a/src/components/ble/NimbleController.h
+++ b/src/components/ble/NimbleController.h
@@ -9,7 +9,7 @@
 #undef min
 #include "components/ble/AlertNotificationClient.h"
 #include "components/ble/AlertNotificationService.h"
-#include "components/ble/AppleNotificationCenterService.h"
+#include "components/ble/AppleNotificationCenterClient.h"
 #include "components/ble/BatteryInformationService.h"
 #include "components/ble/CurrentTimeClient.h"
 #include "components/ble/CurrentTimeService.h"
@@ -103,7 +103,7 @@ namespace Pinetime {
       CurrentTimeClient currentTimeClient;
       AlertNotificationService anService;
       AlertNotificationClient alertNotificationClient;
-      AppleNotificationCenterService appleNotificationCenterService;
+      AppleNotificationCenterClient appleNotificationCenterClient;
       CurrentTimeService currentTimeService;
       MusicService musicService;
       WeatherService weatherService;

--- a/src/components/ble/NimbleController.h
+++ b/src/components/ble/NimbleController.h
@@ -9,6 +9,7 @@
 #undef min
 #include "components/ble/AlertNotificationClient.h"
 #include "components/ble/AlertNotificationService.h"
+#include "components/ble/AppleNotificationCenterService.h"
 #include "components/ble/BatteryInformationService.h"
 #include "components/ble/CurrentTimeClient.h"
 #include "components/ble/CurrentTimeService.h"
@@ -102,6 +103,7 @@ namespace Pinetime {
       CurrentTimeClient currentTimeClient;
       AlertNotificationService anService;
       AlertNotificationClient alertNotificationClient;
+      AppleNotificationCenterService appleNotificationCenterService;
       CurrentTimeService currentTimeService;
       MusicService musicService;
       WeatherService weatherService;

--- a/src/components/ble/ServiceDiscovery.cpp
+++ b/src/components/ble/ServiceDiscovery.cpp
@@ -4,7 +4,7 @@
 
 using namespace Pinetime::Controllers;
 
-ServiceDiscovery::ServiceDiscovery(std::array<BleClient*, 2>&& clients) : clients {clients} {
+ServiceDiscovery::ServiceDiscovery(std::array<BleClient*, 3>&& clients) : clients {clients} {
 }
 
 void ServiceDiscovery::StartDiscovery(uint16_t connectionHandle) {

--- a/src/components/ble/ServiceDiscovery.h
+++ b/src/components/ble/ServiceDiscovery.h
@@ -9,13 +9,13 @@ namespace Pinetime {
 
     class ServiceDiscovery {
     public:
-      ServiceDiscovery(std::array<BleClient*, 2>&& bleClients);
+      ServiceDiscovery(std::array<BleClient*, 3>&& bleClients);
 
       void StartDiscovery(uint16_t connectionHandle);
 
     private:
       BleClient** clientIterator;
-      std::array<BleClient*, 2> clients;
+      std::array<BleClient*, 3> clients;
       void OnServiceDiscovered(uint16_t connectionHandle);
       void DiscoverNextService(uint16_t connectionHandle);
     };


### PR DESCRIPTION
This PR enable support of Apple Notification Center  Service. The current state of this PR is as follow :

- [X] Create initial mapping for ANCS event
- [X] Map ANCS Characteristic UUID
- [X] Initial implementation for notification source characteristic
- [ ] Replace default alert implementation by ANCS when connected to a apple device
- [ ] Enable and test encryption on ANCS characteristic
- [ ] Use Service Changed characteristic
- [ ] Implement usage of control point characteristic
- [ ] Implement usage of Datasource characteristic
- [ ] Build a setup to debug on pinewatch
